### PR TITLE
chore: make Dependabot updates safer for Android

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,50 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 8
     groups:
-      gradle-dependencies:
+      android-toolchain:
         patterns:
-          - "*"
+          - "com.android.application"
+          - "org.jetbrains.kotlin.android"
+          - "org.jetbrains.kotlin.plugin.serialization"
+      quality-tools:
+        patterns:
+          - "org.jlleitschuh.gradle.ktlint"
+          - "io.gitlab.arturbosch.detekt"
+          - "io.gitlab.arturbosch.detekt:*"
+      androidx-runtime:
+        patterns:
+          - "androidx.compose:*"
+          - "androidx.core:*"
+          - "androidx.lifecycle:*"
+          - "androidx.activity:*"
+          - "androidx.security:*"
+      networking-and-serialization:
+        patterns:
+          - "org.jetbrains.kotlinx:*"
+          - "com.squareup.okhttp3:*"
+      android-tests:
+        patterns:
+          - "androidx.test:*"
+          - "junit:*"
+    ignore:
+      - dependency-name: "com.android.application"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.jetbrains.kotlin.android"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.jetbrains.kotlin.plugin.serialization"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.jlleitschuh.gradle.ktlint"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.squareup.okhttp3:okhttp"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.squareup.okhttp3:logging-interceptor"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "io.gitlab.arturbosch.detekt:*"
       androidx-runtime:
         patterns:
-          - "androidx.compose:*"
+          - "androidx.compose*:*"
           - "androidx.core:*"
           - "androidx.lifecycle:*"
           - "androidx.activity:*"
@@ -29,7 +29,7 @@ updates:
           - "com.squareup.okhttp3:*"
       android-tests:
         patterns:
-          - "androidx.test:*"
+          - "androidx.test*:*"
           - "junit:*"
     ignore:
       - dependency-name: "com.android.application"


### PR DESCRIPTION
## Why\nThe current Dependabot setup groups almost all Gradle updates into one PR, which is too blunt for this Android project. That created PRs with major AGP, Kotlin, ktlint, and OkHttp jumps mixed together with harmless patch/minor updates.\n\n## What this changes\n- splits Gradle updates into smaller groups:\n  - android-toolchain\n  - quality-tools\n  - androidx-runtime\n  - networking-and-serialization\n  - android-tests\n- keeps GitHub Actions updates grouped together\n- ignores major-version updates for the riskiest dependencies for now:\n  - AGP\n  - Kotlin Android plugin\n  - Kotlin serialization plugin\n  - ktlint\n  - OkHttp / logging-interceptor\n\n## Why this strategy\nThis should make future update PRs:\n- easier to review from mobile\n- less likely to break CI all at once\n- more aligned with the current maturity of the repo\n\n## Follow-up\nAfter the Gradle wrapper is committed, we should continue tightening CI and then upgrade major toolchain pieces intentionally rather than through a giant grouped Dependabot PR.