### PR TITLE
chore: make ktlint Compose-aware

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+indent_style = space
+indent_size = 4
+max_line_length = 140
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/app/src/main/java/com/kyle/nanogptapp/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/data/settings/SettingsRepository.kt
@@ -12,7 +12,10 @@ import kotlinx.coroutines.flow.asStateFlow
 class SettingsRepository(context: Context) {
     private val appContext = context.applicationContext
 
-    private val prefs: SharedPreferences = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = appContext.getSharedPreferences(
+        PREFS_NAME,
+        Context.MODE_PRIVATE,
+    )
 
     private val securePrefs: SharedPreferences = EncryptedSharedPreferences.create(
         appContext,
@@ -21,7 +24,7 @@ class SettingsRepository(context: Context) {
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build(),
         EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
     )
 
     private val _settings = MutableStateFlow(readSettings())
@@ -76,7 +79,7 @@ class SettingsRepository(context: Context) {
             reasoningEnabled = prefs.getBoolean(KEY_REASONING_ENABLED, false),
             searchEnabled = prefs.getBoolean(KEY_SEARCH_ENABLED, false),
             memoryEnabled = prefs.getBoolean(KEY_MEMORY_ENABLED, false),
-            mediaEnabled = prefs.getBoolean(KEY_MEDIA_ENABLED, false)
+            mediaEnabled = prefs.getBoolean(KEY_MEDIA_ENABLED, false),
         )
     }
 

--- a/app/src/main/java/com/kyle/nanogptapp/model/AppSettings.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/model/AppSettings.kt
@@ -12,5 +12,5 @@ data class AppSettings(
     val reasoningEnabled: Boolean = false,
     val searchEnabled: Boolean = false,
     val memoryEnabled: Boolean = false,
-    val mediaEnabled: Boolean = false
+    val mediaEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/kyle/nanogptapp/model/ChatModels.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/model/ChatModels.kt
@@ -7,7 +7,7 @@ package com.kyle.nanogptapp.model
  */
 data class ChatMessage(
     val role: String,
-    val content: String
+    val content: String,
 )
 
 data class ChatRequest(
@@ -15,12 +15,12 @@ data class ChatRequest(
     val messages: List<ChatMessage>,
     val reasoningEnabled: Boolean = false,
     val reasoningEffort: String = "low",
-    val stream: Boolean = false
+    val stream: Boolean = false,
 )
 
 data class ModelSummary(
     val id: String,
     val displayName: String = id,
     val supportsVision: Boolean = false,
-    val supportsReasoning: Boolean = false
+    val supportsReasoning: Boolean = false,
 )

--- a/app/src/main/java/com/kyle/nanogptapp/ui/AppRoot.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/ui/AppRoot.kt
@@ -27,25 +27,27 @@ fun AppRoot() {
     var selectedTab by remember { mutableIntStateOf(0) }
     val tabs = listOf("Chat", "Settings")
     val context = LocalContext.current
-    val settingsRepository = remember(context) { SettingsGraph.repository(context) }
+    val settingsRepository = remember(context) {
+        SettingsGraph.repository(context)
+    }
     val settings by settingsRepository.settings.collectAsState()
 
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("NanoGPT") })
-        }
+        },
     ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
+                .padding(innerPadding),
         ) {
             TabRow(selectedTabIndex = selectedTab) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
                         selected = selectedTab == index,
                         onClick = { selectedTab = index },
-                        text = { Text(title) }
+                        text = { Text(title) },
                     )
                 }
             }

--- a/app/src/main/java/com/kyle/nanogptapp/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/ui/chat/ChatScreen.kt
@@ -26,10 +26,13 @@ fun ChatScreen(hasApiKey: Boolean) {
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Card(modifier = Modifier.fillMaxWidth()) {
-            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 Text("Chat milestone")
                 Text("This screen is the first target: text chat, model selection, then streaming.")
                 Text("The architecture is being kept open for future image and video generation flows.")
@@ -44,7 +47,7 @@ fun ChatScreen(hasApiKey: Boolean) {
             onValueChange = { input = it },
             modifier = Modifier.fillMaxWidth(),
             label = { Text("Message") },
-            enabled = hasApiKey
+            enabled = hasApiKey,
         )
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/kyle/nanogptapp/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/ui/settings/SettingsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
@@ -45,7 +44,7 @@ fun SettingsScreen() {
     val viewModel: SettingsViewModel = viewModel(factory = factory)
     val uiState by viewModel.uiState.collectAsState()
 
-    SettingsScreen(
+    SettingsContent(
         uiState = uiState,
         onApiKeyInputChanged = viewModel::onApiKeyInputChanged,
         onApiKeyVisibilityChanged = viewModel::onApiKeyVisibilityChanged,
@@ -54,13 +53,12 @@ fun SettingsScreen() {
         onReasoningChanged = viewModel::updateReasoningEnabled,
         onSearchChanged = viewModel::updateSearchEnabled,
         onMemoryChanged = viewModel::updateMemoryEnabled,
-        onMediaChanged = viewModel::updateMediaEnabled
+        onMediaChanged = viewModel::updateMediaEnabled,
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SettingsScreen(
+private fun SettingsContent(
     uiState: SettingsUiState,
     onApiKeyInputChanged: (String) -> Unit,
     onApiKeyVisibilityChanged: (Boolean) -> Unit,
@@ -69,19 +67,19 @@ private fun SettingsScreen(
     onReasoningChanged: (Boolean) -> Unit,
     onSearchChanged: (Boolean) -> Unit,
     onMemoryChanged: (Boolean) -> Unit,
-    onMediaChanged: (Boolean) -> Unit
+    onMediaChanged: (Boolean) -> Unit,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(
                 modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text("Secure credentials")
                 Text(
@@ -89,7 +87,7 @@ private fun SettingsScreen(
                         "A NanoGPT API key is stored in encrypted on-device preferences."
                     } else {
                         "No API key saved yet. Add one before wiring up live API calls."
-                    }
+                    },
                 )
 
                 OutlinedTextField(
@@ -103,15 +101,19 @@ private fun SettingsScreen(
                     } else {
                         PasswordVisualTransformation()
                     },
-                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.None,
+                    ),
                     supportingText = {
-                        Text("Stored locally only. Future network clients can read it through the settings repository.")
-                    }
+                        Text(
+                            "Stored locally only. Future network clients can read it through the settings repository.",
+                        )
+                    },
                 )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     OutlinedButton(onClick = { onApiKeyVisibilityChanged(!uiState.isApiKeyVisible) }) {
                         Text(if (uiState.isApiKeyVisible) "Hide" else "Show")
@@ -131,34 +133,56 @@ private fun SettingsScreen(
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(
                 modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text("Feature toggles")
-                SettingToggle("Reasoning", uiState.settings.reasoningEnabled, onReasoningChanged)
-                SettingToggle("Web search (:online)", uiState.settings.searchEnabled, onSearchChanged)
-                SettingToggle("Memory (:memory)", uiState.settings.memoryEnabled, onMemoryChanged)
-                SettingToggle("Future media generation path", uiState.settings.mediaEnabled, onMediaChanged)
+                SettingsToggle(
+                    label = "Reasoning",
+                    checked = uiState.settings.reasoningEnabled,
+                    onCheckedChange = onReasoningChanged,
+                )
+                SettingsToggle(
+                    label = "Web search (:online)",
+                    checked = uiState.settings.searchEnabled,
+                    onCheckedChange = onSearchChanged,
+                )
+                SettingsToggle(
+                    label = "Memory (:memory)",
+                    checked = uiState.settings.memoryEnabled,
+                    onCheckedChange = onMemoryChanged,
+                )
+                SettingsToggle(
+                    label = "Future media generation path",
+                    checked = uiState.settings.mediaEnabled,
+                    onCheckedChange = onMediaChanged,
+                )
             }
         }
 
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(
                 modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text("Settings architecture")
                 Text("This pass keeps secure credentials separate from general app preferences.")
-                Text("That leaves room for future model selection, image/video defaults, render settings, and account-level toggles without rewriting the storage layer.")
+                Text(
+                    "That leaves room for future model selection, image/video defaults, render settings, and account-level toggles without rewriting the storage layer.",
+                )
             }
         }
     }
 }
 
 @Composable
-private fun SettingToggle(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun SettingsToggle(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(label)
         Switch(checked = checked, onCheckedChange = onCheckedChange)

--- a/app/src/main/java/com/kyle/nanogptapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/kyle/nanogptapp/ui/settings/SettingsViewModel.kt
@@ -12,19 +12,19 @@ data class SettingsUiState(
     val settings: AppSettings = AppSettings(),
     val apiKeyInput: String = "",
     val isApiKeyVisible: Boolean = false,
-    val saveMessage: String? = null
+    val saveMessage: String? = null,
 )
 
 class SettingsViewModel(
-    private val repository: SettingsRepository
+    private val repository: SettingsRepository,
 ) : ViewModel() {
     val settings = repository.settings
 
     private val _uiState = MutableStateFlow(
         SettingsUiState(
             settings = repository.settings.value,
-            apiKeyInput = repository.getApiKey()
-        )
+            apiKeyInput = repository.getApiKey(),
+        ),
     )
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
@@ -49,7 +49,7 @@ class SettingsViewModel(
                     "API key saved securely on device"
                 } else {
                     "API key cleared"
-                }
+                },
             )
         }
     }
@@ -60,7 +60,7 @@ class SettingsViewModel(
             it.copy(
                 settings = repository.settings.value,
                 apiKeyInput = "",
-                saveMessage = "API key removed from secure storage"
+                saveMessage = "API key removed from secure storage",
             )
         }
     }


### PR DESCRIPTION
## Why
Our Android CI is currently failing in ktlint for two different reasons:
- standard Kotlin formatting issues
- a mismatch between ktlint's default function naming rule and Jetpack Compose conventions (PascalCase composable names like ChatScreen, SettingsScreen, and AppRoot)

## What this changes
- adds a root .editorconfig
- configures ktlint to ignore function naming violations when a function is annotated with @Composable
- normalizes the currently flagged Kotlin formatting in the main affected files

## Why this is the long-term fix
This keeps ktlint in place, but teaches it about Compose instead of forcing Compose code to fit non-Compose naming rules. That means CI will fail on real style issues rather than producing noisy false positives for normal composable names.

## Scope
This PR is intentionally narrow:
- no architecture changes
- no settings hardening yet
- no Gradle wrapper work yet
- just the Compose-aware lint baseline and code formatting cleanup
